### PR TITLE
fix(ai): Automated bug fixes from BugHunterAgent in pkg/apis/pipeline/v1alpha1

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/run_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/run_defaults.go
@@ -39,7 +39,7 @@ func (rs *RunSpec) SetDefaults(ctx context.Context) {
 		rs.ServiceAccountName = defaultSA
 	}
 	defaultPodTemplate := cfg.Defaults.DefaultPodTemplate
-	if rs.PodTemplate == nil {
-		rs.PodTemplate = defaultPodTemplate
+	if rs.PodTemplate == nil && defaultPodTemplate != nil {
+		rs.PodTemplate = defaultPodTemplate.DeepCopy()
 	}
 }


### PR DESCRIPTION
# BugHunterAgent Change Summary

## Overview

This document summarizes the changes made by the BugHunterAgent to address potential bugs in the `pkg/apis/pipeline/v1alpha1` subdirectory.

## Changes

### File: `pkg/apis/pipeline/v1alpha1/run_defaults.go`

- **Bug Fixed:** Potential race condition due to shared `PodTemplate` object.
- **Description:** The original code assigned the default `PodTemplate` directly to `RunSpec.PodTemplate`. This could lead to multiple `Run` objects sharing the same `PodTemplate` object, creating a potential for race conditions if the `PodTemplate` is modified.
- **Fix:** The code was modified to use a `DeepCopy()` of the `defaultPodTemplate` when assigning it to a `RunSpec`. This ensures that each `Run` has its own isolated `PodTemplate` object, preventing race conditions.
- **Assumption:** This fix assumes that the `pod.PodTemplate` type has a `DeepCopy()` method, which is a common pattern for Kubernetes API objects.